### PR TITLE
Adding game path to settings page 

### DIFF
--- a/launcher-window/local-page/local-page.html
+++ b/launcher-window/local-page/local-page.html
@@ -9,5 +9,5 @@
 </div>
 
 
-
+<script src="settings-page/settings-page.js"></script>
 <script src='local-page/local-page.js'></script>

--- a/launcher-window/local-page/local-page.js
+++ b/launcher-window/local-page/local-page.js
@@ -46,10 +46,12 @@ function findDSPath() {
 function displayPathInfo() {
 	if (executablePath) {
 		$('#info').text(`Docking Station Path set to ${executablePath}`);
+		$('#find-path-button').hide();
 		$('#launch-button').show();
 	} else {
-		$('#info').text('No Docking Station Path was found...');
+		$('#info').text('Your Docking Station path could not be automatically detected.');
 		$('#launch-button').hide();
+		$('#find-path-button').show();
 	}
 }
 
@@ -63,6 +65,7 @@ function validateDSPath(path) {
 		} else {
 			$('#info').text(`Sorry, ${pathString} isn't a valid path. (Valid paths contain an engine.exe file)`);
 			$('#launch-button').hide();
+			$('#find-path-button').show();
 		}
 	}
 }

--- a/launcher-window/local-page/local-page.js
+++ b/launcher-window/local-page/local-page.js
@@ -1,8 +1,3 @@
-var executablePath = false;
-const { dialog } = require('electron').remote
-const fs = require("fs");
-
-
 function launchDockingStation(){
   var { spawn } = require('child_process');
 
@@ -20,60 +15,4 @@ function launchDockingStation(){
 	}
 }
 
-
-function findDSPath() {
-	// checking settings first
-	if (settings.get('gamePath')) {
-		return settings.get('gamePath');
-	}
-	// then try to guess based on common paths
-	// (should maybe externalize these at some point?)
-	const possiblePaths = [
-	'C:/Program Files (x86)/GOG Galaxy/Games/Creatures Exodus/Docking Station',
-	'C:/Program Files (x86)/Docking Station',
-	'C:/Program Files/Docking Station',
-	`C:${(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE).split('\\').join('/')}/Documents/Creatures/Docking Station`
-	]
-	for (const path of possiblePaths) {
-		if (fs.existsSync(`${path}/engine.exe`)) {
-			settings.set('gamePath', path);
-			return path;
-		}
-	}
-	return false;
-}
-
-function displayPathInfo() {
-	if (executablePath) {
-		$('#info').text(`Docking Station Path set to ${executablePath}`);
-		$('#find-path-button').hide();
-		$('#launch-button').show();
-	} else {
-		$('#info').text('Your Docking Station path could not be automatically detected.');
-		$('#launch-button').hide();
-		$('#find-path-button').show();
-	}
-}
-
-function validateDSPath(path) {
-	if(path) {
-		const pathString = path.toString();
-		if (fs.existsSync(`${pathString}/engine.exe`)) {
-			executablePath = pathString;
-			settings.set('gamePath', pathString);
-			displayPathInfo();
-		} else {
-			$('#info').text(`Sorry, ${pathString} isn't a valid path. (Valid paths contain an engine.exe file)`);
-			$('#launch-button').hide();
-			$('#find-path-button').show();
-		}
-	}
-}
-
-function selectDSPath() {
-	validateDSPath(dialog.showOpenDialogSync({ properties: ['openDirectory', 'multiSelections'] }));
-}
-
-//this seems unsafe... should there be a check if the content is loaded before running this?
-executablePath =  findDSPath();
-displayPathInfo();
+// gamepath display stuff is in in settings-page)

--- a/launcher-window/settings-page/settings-page.css
+++ b/launcher-window/settings-page/settings-page.css
@@ -2,3 +2,8 @@
   font-weight: 300;
   font-size: 0.7rem;
 }
+
+.setting-block {
+	padding-top: 10px;
+	padding-botton: 10px;
+}

--- a/launcher-window/settings-page/settings-page.html
+++ b/launcher-window/settings-page/settings-page.html
@@ -1,6 +1,6 @@
 <link rel="stylesheet" type="text/css" href="settings-page/settings-page.css">
 
-<div style='background-color: rgb(71,59,99);'>
+<div class = "setting-block" style='background-color: rgb(71,59,99);'>
   <form>
     <input class='setting-checkbox' type='checkbox' id='dev-js-checkbox' data-backend-name='development.javascript' data-default=false>
     <span>JavaScript Developer Tools</span>
@@ -11,11 +11,11 @@
   </form>
 </div>
 
-<div style='background-color: rgb(71,59,99);'>
-	<span id='find-path-button'>
+<div class = "setting-block" style='background-color: rgb(71,59,99);'>
+	<div id='find-path-button'>
 		<button onclick='selectDSPath()'>Set Docking Station Game Path </button>
-	</span>
-	<span id='info'>Not set.</span>
+	</div>
+	<div id='info' class='setting-checkbox-statehint'></div>
 </div>	
 
 

--- a/launcher-window/settings-page/settings-page.html
+++ b/launcher-window/settings-page/settings-page.html
@@ -11,4 +11,12 @@
   </form>
 </div>
 
+<div style='background-color: rgb(71,59,99);'>
+	<span id='find-path-button'>
+		<button onclick='selectDSPath()'>Set Docking Station Game Path </button>
+	</span>
+	<span id='info'>Not set.</span>
+</div>	
+
+
 <script src="settings-page/settings-page.js"></script>

--- a/launcher-window/settings-page/settings-page.html
+++ b/launcher-window/settings-page/settings-page.html
@@ -12,7 +12,7 @@
 </div>
 
 <div class = "setting-block" style='background-color: rgb(71,59,99);'>
-	<div id='find-path-button'>
+	<div id='set-path-button'>
 		<button onclick='selectDSPath()'>Set Docking Station Game Path </button>
 	</div>
 	<div id='info' class='setting-checkbox-statehint'></div>

--- a/launcher-window/settings-page/settings-page.js
+++ b/launcher-window/settings-page/settings-page.js
@@ -45,9 +45,9 @@ function findDSPath() {
 
 function displayPathInfo() {
   if (executablePath) {
-    $('#info').text(`${executablePath}`);
+    $('#info').text(`Current Path: ${executablePath}`);
   } else {
-    $('#info').text('Your Docking Station path could not be automatically detected.');
+    $('#info').text('Your Docking Station path could not be automatically detected. Please set one manually.');
 
   }
 }

--- a/launcher-window/settings-page/settings-page.js
+++ b/launcher-window/settings-page/settings-page.js
@@ -1,3 +1,4 @@
+// devtools checkbox
 $('.setting-checkbox').each(function() {
   this.checked = settings.get(this.getAttribute('data-backend-name'), this.getAttribute('data-default'))
   this.addEventListener('change', (event) => {
@@ -7,6 +8,10 @@ $('.setting-checkbox').each(function() {
   setStatehint(this);
  });
 
+// gamepath display
+executablePath =  findDSPath();
+displayPathInfo();
+
 function setStatehint(checkbox){
   let stateHintDivSelector = '#' + checkbox.id + '-statehint';
   $(stateHintDivSelector).text('(' + (
@@ -14,4 +19,52 @@ function setStatehint(checkbox){
     ? $(stateHintDivSelector).attr('data-checked-statehint')
     : $(stateHintDivSelector).attr('data-unchecked-statehint')
   ) + ')');
+}
+
+function findDSPath() {
+  // checking settings first
+  if (settings.get('gamePath')) {
+    return settings.get('gamePath');
+  }
+  // then try to guess based on common paths
+  // (should maybe externalized these at some point?)
+  const possiblePaths = [
+  'C:/Program Files (x86)/GOG Galaxy/Games/Creatures Exodus/Docking Station',
+  'C:/Program Files (x86)/Docking Station',
+  'C:/Program Files/Docking Station',
+  `C:${(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE).split('\\').join('/')}/Documents/Creatures/Docking Station`
+  ]
+  for (const path of possiblePaths) {
+    if (fs.existsSync(`${path}/engine.exe`)) {
+      settings.set('gamePath', path);
+      return path;
+    }
+  }
+  return false;
+}
+
+function displayPathInfo() {
+  if (executablePath) {
+    $('#info').text(`${executablePath}`);
+  } else {
+    $('#info').text('Your Docking Station path could not be automatically detected.');
+
+  }
+}
+
+function validateDSPath(path) {
+  if(path) {
+    const pathString = path.toString();
+    if (fs.existsSync(`${pathString}/engine.exe`)) {
+      executablePath = pathString;
+      settings.set('gamePath', pathString);
+      displayPathInfo();
+    } else {
+      $('#info').text(`Sorry, ${pathString} isn't a valid path. (Valid paths contain an engine.exe file)`);
+    }
+  }
+}
+
+function selectDSPath() {
+  validateDSPath(dialog.showOpenDialogSync({ properties: ['openDirectory', 'multiSelections'] }));
 }


### PR DESCRIPTION
This is technically functional (to my knowledge) but a large amount of the pathfinding JS here was lazily copy-pasted from the local-page,js-- for the future is there a preferred way of handling that (linking one from the other, or having a shared file linked from both) that fits nicely/doesn't clash with the project structure you have in place already?

(Also I took the liberty of throwing in some padding because it looked a little crowded but I'm not too attached to it if you have another vision in mind.)