### PR TITLE
Fix for CAOS.dll location.

### DIFF
--- a/engine-api/CAOS.js
+++ b/engine-api/CAOS.js
@@ -2,7 +2,7 @@ var edge = require('electron-edge-js');
 var path = require('path');
 
 var executeCaos = edge.func(`
-#r "engine-api/CAOS.dll"
+#r "resources/app/engine-api/CAOS.dll"
 using CAOS;
 
 async (input) => {


### PR DESCRIPTION
Should have been in v0.0.0.5-beta, but I forgot to commit it. So it's not in the tag. But it is in the .zip file. So, yeah...