### PR TITLE
Fix broken image loading

### DIFF
--- a/src/cartographers-table-window/index.ts
+++ b/src/cartographers-table-window/index.ts
@@ -313,7 +313,7 @@ function redoMultiCommand({subcommands}: { subcommands: Command[] }) {
 async function newFile() {
     await fileHelper.newFile();
     let backgroundFile = await fileHelper.selectBackgroundFile();
-    const isBlk = path.extname(backgroundFile).toLowerCase();
+    const isBlk = path.extname(backgroundFile).toLowerCase() === '.blk';
     let width: number;
     let height: number;
     if (isBlk) {


### PR DESCRIPTION
`isBlk` check added for BLK caching failed to actually compare extension to `.blk`, resulting in all files loaded asynchronously with file creation happening before image load.